### PR TITLE
Add serverless-architecture-boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This table is generated from https://github.com/serverless/examples/blob/master/
 -->
 | Project Name | Author |
 |:-------------|:------:|
+| **[Serverless Architecture Boilerplate](https://github.com/msfidelis/serverless-architecture-boilerplate)** <br/> Boilerplate to organize and deploy big projects using Serverless and CloudFormation on AWS | [msfidelis](http://github.com/msfidelis) |
 | **[Jwtauthorizr](https://github.com/serverlessbuch/jwtAuthorizr)** <br/> Custom JWT Authorizer Lambda function for Amazon API Gateway with Bearer JWT | [serverlessbuch](http://github.com/serverlessbuch) |
 | **[Serverless Graphql Api](https://github.com/boazdejong/serverless-graphql-api)** <br/> Serverless GraphQL API using Lambda and DynamoDB | [boazdejong](http://github.com/boazdejong) |
 | **[Serverless Screenshot](https://github.com/svdgraaf/serverless-screenshot)** <br/> Serverless Screenshot Service using PhantomJS | [svdgraaf](http://github.com/svdgraaf) |


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Adding the [Serverless Architecture Boilerplate](https://github.com/msfidelis/serverless-architecture-boilerplate) used on [PJBank](https://pjbank.com.br) and [Superlógica Tecnologias](https://superlogica.com) to create and deploy, test and manage API Microservices Endpoints, Background Workers and AWS Cloudformation Stack with Serverless Framework.  

We have 10 high throughput microservices workloads with 45 API Endpoints and 30 Background workers consuming AWS Services like SQS, SNS, Kinesis, DynamoDB, S3, RDS, Elasticache, ElasticSearch and Cloudwatch built with this boilerplate. 

I create a PR on Examples Repository https://github.com/serverless/examples/pull/244, but i don't know if it's deprecated. If does, please notify me to close this PR. 

***Is this ready for review?:*** Yes
***Is it a breaking change?:*** NO
